### PR TITLE
Add components package for GOV.UK applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This shows the current known govuk-frontend version of services, based on their 
 | Service | govuk-frontend version |
 | ------- | --------------------- |
 | [GOV.UK Design System](https://github.com/alphagov/govuk-design-system/) | ^5.1.0 |
+| [GOV.UK Platform as a Service](https://github.com/alphagov/paas-product-pages/) | ^5.1.0 |
+| [Get a new energy certificate](https://github.com/communitiesuk/epb-frontend/) | ^5.1.0 |
 | [Product safety database](https://github.com/UKGovernmentBEIS/beis-opss-psd/) | 5.1.0 |
 | [Submit cosmetic product notifications](https://github.com/UKGovernmentBEIS/beis-opss-cosmetics/cosmetics-web/) | 5.1.0 |
 | [Access your teaching qualifications](https://github.com/DFE-Digital/access-your-teaching-qualifications/) | ^5.0.0 |
@@ -15,13 +17,12 @@ This shows the current known govuk-frontend version of services, based on their 
 | [GOV.UK Forms (Product pages)](https://github.com/alphagov/forms-product-page/) | ^5.0.0 |
 | [GOV.UK Forms (Admin application)](https://github.com/alphagov/forms-admin/) | ~5.0.0 |
 | [GOV.UK Forms (Forms runner)](https://github.com/alphagov/forms-runner/) | ~5.0.0 |
-| [GOV.UK Platform as a Service](https://github.com/alphagov/paas-product-pages/) | ^5.0.0 |
 | [GOV.UK Prototype Kit](https://github.com/alphagov/govuk-prototype-kit/) | 5.0.0 |
-| [Get a new energy certificate](https://github.com/communitiesuk/epb-frontend/) | ^5.0.0 |
 | [Manage training for early career teachers](https://github.com/DFE-Digital/early-careers-framework/) | ^5.0.0 |
 | [Register trainee teachers](https://github.com/DFE-Digital/register-trainee-teachers/) | ^5.0.0 |
 | [Submit social housing lettings and sales data (CORE)](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/) | 5.0.0 |
 | [Teaching Vacancies](https://github.com/DFE-Digital/teaching-vacancies/) | ^5.0.0 |
+| [GOV.UK](https://github.com/alphagov/govuk_publishing_components/) | ^4.8.0 |
 | [Find a grant](https://github.com/cabinetoffice/gap-find-apply-web/packages/applicant/) | ^4.8 |
 | [Apply for teacher training](https://github.com/DFE-Digital/apply-for-teacher-training/) | ^4.7.0 |
 | [Calculate teacher pay](https://github.com/DFE-Digital/teacher-pay-calculator/) | 4.7.0 |

--- a/data.json
+++ b/data.json
@@ -95,7 +95,7 @@
     {
       "repo": "alphagov/paas-product-pages",
       "serviceName": "GOV.UK Platform as a Service",
-      "govukversion": "^5.0.0"
+      "govukversion": "^5.1.0"
     },
     {
       "repo": "UKForeignOffice/fco-consular-appointments-slotpicker",
@@ -551,7 +551,7 @@
       "repo": "communitiesuk/epb-frontend",
       "serviceName": "Get a new energy certificate",
       "name": "Energy performance of buildings register front end",
-      "govukversion": "^5.0.0"
+      "govukversion": "^5.1.0"
     },
     {
       "repo": "communitiesuk/epb-register-api",

--- a/data.json
+++ b/data.json
@@ -588,6 +588,13 @@
       "serviceName": "Get a new energy certificate",
       "name": "Energy performance of buildings register infrastructure",
       "skip": "maybe"
+    },
+    {
+      "repo": "alphagov/govuk_publishing_components",
+      "serviceName": "GOV.UK",
+      "govukversion": "^4.8.0",
+      "name": "Frontend components for GOV.UK applications",
+      "skip": "no"
     }
   ]
 }


### PR DESCRIPTION
The publishing applications for GOV.‌UK use the govuk_publishing_components gem for all frontend components. This PR adds that repo to the list to be checked.