### PR TITLE
Fix repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following table shows the current version of [GOV.UK Frontend](https://githu
 | [Publish teacher training courses](https://github.com/DFE-Digital/publish-teacher-training/) | 5.2.0 | 👑 |
 | [Register trainee teachers](https://github.com/DFE-Digital/register-trainee-teachers/) | ^5.2.0 | 👑 |
 | [Send legal mail to prisons](https://github.com/ministryofjustice/send-legal-mail-to-prisons/) | ^5.2.0 | 👑 |
-| [Submit cosmetic product notifications](https://github.com/UKGovernmentBEIS/beis-opss-cosmetics/cosmetics-web/) | 5.2.0 | 👑 |
+| [Submit cosmetic product notifications](https://github.com/UKGovernmentBEIS/beis-opss-cosmetics/tree/main/cosmetics-web/) | 5.2.0 | 👑 |
 | [Teaching Vacancies](https://github.com/DFE-Digital/teaching-vacancies/) | ^5.2.0 | 👑 |
 | [Visit someone in prison – Staff-facing manage service](https://github.com/ministryofjustice/book-a-prison-visit-staff-ui/) | ^5.2.0 | 👑 |
 | [Check if your client qualifies for legal aid](https://github.com/ministryofjustice/laa-estimate-financial-eligibility-for-legal-aid/) | ^5.1.0 | 👑 |
@@ -26,7 +26,7 @@ The following table shows the current version of [GOV.UK Frontend](https://githu
 | [GOV.UK Forms – Product pages](https://github.com/alphagov/forms-product-page/) | 5.1.0 | 👑 |
 | [GOV.UK Forms – Admin application](https://github.com/alphagov/forms-admin/) | 5.1.0 | 👑 |
 | [Get Into Teaching](https://github.com/DFE-Digital/get-into-teaching-app/) | ^5.1.0 | 👑 |
-| [Get a rod fishing licence](https://github.com/DEFRA/rod-licensing/packages/gafl-webapp-service/) | ^5.1.0 | 👑 |
+| [Get a rod fishing licence](https://github.com/DEFRA/rod-licensing/tree/main/packages/gafl-webapp-service/) | ^5.1.0 | 👑 |
 | [Submit social housing lettings and sales data (CORE)](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data/) | 5.1.0 | 👑 |
 | [Visit someone in prison – Public-facing booking service](https://github.com/ministryofjustice/hmpps-book-a-prison-visit-ui/) | ^5.1.0 | 👑 |
 | [Apply for teacher training](https://github.com/DFE-Digital/apply-for-teacher-training/) | ^5.0.0 |  |
@@ -36,46 +36,45 @@ The following table shows the current version of [GOV.UK Frontend](https://githu
 | [Flood map for planning](https://github.com/DEFRA/fmp-app/) | ^4.8.0 | 👑 |
 | [GOV.UK One Login – Authentication frontend](https://github.com/govuk-one-login/authentication-frontend/) | ^4.8.0 | 👑 |
 | [GOV.UK One Login – Product page](https://github.com/govuk-one-login/onboarding-product-page/) | ^4.8.0 | 👑 |
-| [GOV.UK One Login – Admin tool](https://github.com/govuk-one-login/onboarding-self-service-experience/express/) | ^4.8.0 | 👑 |
+| [GOV.UK One Login – Admin tool](https://github.com/govuk-one-login/onboarding-self-service-experience/tree/main/express/) | ^4.8.0 | 👑 |
 | [GOV.UK One Login – Account management frontend](https://github.com/govuk-one-login/di-account-management-frontend/) | ^4.8.0 | 👑 |
 | [Get help with the cost of prison visits](https://github.com/ministryofjustice/help-with-prison-visits-external/) | ^4.8.0 | 👑 |
 | [Register for a National Professional Qualification](https://github.com/DFE-Digital/npq-registration/) | ^4.8.0 | 👑 |
-| [Find a grant](https://github.com/cabinetoffice/gap-find-apply-web/packages/applicant/) | ^4.8 | 👑 |
+| [Find a grant](https://github.com/cabinetoffice/gap-find-apply-web/tree/main/packages/applicant/) | ^4.8 | 👑 |
 | [GOV.UK Pay](https://github.com/alphagov/pay-frontend/) | ^4.7.8 |  |
 | [Calculate teacher pay](https://github.com/DFE-Digital/teacher-pay-calculator/) | 4.7.0 |  |
-| [Develop your career in child and family social work](https://github.com/DFE-Digital/childrens-social-care-cpd/Childrens-Social-Care-CPD/) | ^4.7.0 |  |
+| [Develop your career in child and family social work](https://github.com/DFE-Digital/childrens-social-care-cpd/tree/main/Childrens-Social-Care-CPD/) | ^4.7.0 |  |
 | [Early years child development training](https://github.com/DFE-Digital/early-years-foundation-recovery/) | ^4.7.0 |  |
 | [Get help buying for schools](https://github.com/DFE-Digital/buy-for-your-school/) | ^4.7.0 |  |
 | [Get help paying court and tribunal fees](https://github.com/ministryofjustice/hwf-publicapp/) | ^4.7.0 |  |
 | [GovWifi](https://github.com/alphagov/govwifi-product-page/) | ^4.7.0 |  |
 | [Look up commodity codes, import duties, taxes and controls (UK Integrated Online Tariff) – Front end](https://github.com/trade-tariff/trade-tariff-frontend/) | ^4.7.0 |  |
 | [Look up commodity codes, import duties, taxes and controls (UK Integrated Online Tariff) – Calculator front end](https://github.com/trade-tariff/trade-tariff-duty-calculator/) | ^4.7.0 |  |
-| [Plan technology for your school](https://github.com/DFE-Digital/plan-technology-for-your-school/src/Dfe.PlanTech.Web.Node/) | ^4.7.0 |  |
+| [Plan technology for your school](https://github.com/DFE-Digital/plan-technology-for-your-school/tree/main/src/Dfe.PlanTech.Web.Node/) | ^4.7.0 |  |
 | [Refer serious misconduct by a teacher in England](https://github.com/DFE-Digital/refer-serious-misconduct/) | 4.7.0 |  |
 | [Support for early career teachers](https://github.com/DFE-Digital/support-for-early-career-teachers/) | 4.7.0 |  |
 | [Verify an apostille](https://github.com/UKForeignOffice/verify-apostille-service/) | ^4.7.0 |  |
 | [Apply for Probate](https://github.com/hmcts/probate-frontend/) | ^4.6.0 |  |
 | [Find a teaching school hub](https://github.com/DFE-Digital/teaching-school-hub-finder/) | 4.6.0 |  |
 | [Find postgraduate teacher training](https://github.com/DFE-Digital/find-teacher-training/) | ^4.4.1 |  |
-| [Home Office Design System](https://github.com/UKHomeOffice/home-office-design-system/components/page/) | 4.4.1 |  |
+| [Home Office Design System](https://github.com/UKHomeOffice/home-office-design-system/tree/main/components/page/) | 4.4.1 |  |
 | [Claim Additional Payments for Teaching](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/) | ^4.3.1 |  |
-| [GOV.UK Notify](https://github.com/alphagov/notifications-admin/) | 4.2.0 |  |
 | [planning.data.gov.uk](https://github.com/digital-land/digital-land.info/) | 4.2.0 |  |
 | [Create an energy label](https://github.com/UKGovernmentBEIS/energy-label-service/) | ^4.0.1 |  |
-| [Gender pay gap reporting](https://github.com/cabinetoffice/gender-pay-gap/GenderPayGap.WebUI/) | ^4.0.1 |  |
+| [Gender pay gap reporting](https://github.com/cabinetoffice/gender-pay-gap/tree/main/GenderPayGap.WebUI/) | ^4.0.1 |  |
 | [Get school experience](https://github.com/DFE-Digital/schools-experience/) | ^4.0.1 |  |
 | [Sign up for flood warnings](https://github.com/DEFRA/flood-xws-contact-web/) | 4.0.0 |  |
 | [Find and Use an API](https://github.com/DFE-Digital/eapim-developer-hub/) | ^3.6.0 |  |
 | [National Pupil Database (NPD)](https://github.com/DFE-Digital/npd-find-and-explore/) | ^3.5.0 |  |
-| [Apply for innovation funding](https://github.com/InnovateUKGitHub/innovation-funding-service/ifs-web-service/) | ^3.3.0 |  |
-| [Appeal a planning decision](https://github.com/Planning-Inspectorate/appeal-planning-decision/packages/web-comment/) | ^3.15.0 | 👑 |
+| [Apply for innovation funding](https://github.com/InnovateUKGitHub/innovation-funding-service/tree/main/ifs-web-service/) | ^3.3.0 |  |
+| [Appeal a planning decision](https://github.com/Planning-Inspectorate/appeal-planning-decision/tree/main/packages/web-comment/) | ^3.15.0 | 👑 |
 | [Report your salmon or sea trout catch](https://github.com/DEFRA/rod-catch-returns-frontend/) | ^3.15.0 | 👑 |
 | [Apply for a Gender Recognition Certificate](https://github.com/cabinetoffice/grc-app/) | ^3.14.0 |  |
 | [Coronavirus (COVID-19) in the UK ](https://github.com/publichealthengland/coronavirus-dashboard/) | ^3.14.0 |  |
 | [Home Office Forms](https://github.com/UKHomeOfficeForms/hof/) | 3.14 |  |
 | [King's Awards for Enterprise](https://github.com/bitzesty/qae/) | ^3.13.0 |  |
 | [The King’s Award for Voluntary Service](https://github.com/bitzesty/qavs-v2/) | ^3.13.0 |  |
-| [Get information about schools](https://github.com/DFE-Digital/get-information-about-schools/Web/Edubase.Web.UI/) | ^3.12.0 |  |
+| [Get information about schools](https://github.com/DFE-Digital/get-information-about-schools/tree/main/Web/Edubase.Web.UI/) | ^3.12.0 |  |
 | [Report your Official Development Assistance](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/) | ^3.11.0 |  |
 | [Report modern slavery](https://github.com/UKHomeOffice/modern-slavery/) | ^2.7.0 |  |
 | [Apply for a divorce](https://github.com/hmcts/div-petitioner-frontend/) | ^2.11.0 |  |

--- a/update.rb
+++ b/update.rb
@@ -120,7 +120,13 @@ File.open("README.md", 'w') do |file|
   repos_with_govuk_frontend.each do |repo|
 
     display_name = repo["serviceName"].to_s
-    repo_url = "https://github.com/#{repo['repo']}/#{repo['packageLocation']}"
+
+    repo_url = "https://github.com/#{repo['repo']}/"
+
+    if repo['packageLocation']
+      repo_url += "tree/main/#{repo['packageLocation']}"
+    end
+
     version = repo["govukversion"].to_s
 
     other_repos_for_same_service = repos_with_govuk_frontend.detect do |other_repo|


### PR DESCRIPTION
Where the package.json isn't at the top level of the repo, the link were broken as they need to have `/tree/main/` in them.