### PR TITLE
Show blue crown for v5.11.x

### DIFF
--- a/update.rb
+++ b/update.rb
@@ -109,7 +109,7 @@ end
 
 def can_rebrand?(version)
   version = version.gsub(/[\^\~]/, "")
-  version.start_with?("4.10") || (version.start_with?("5.10"))
+  version.start_with?("4.10") || (version.start_with?("5.10")) || (version.start_with?("5.11"))
 end
 
 # Update README.md


### PR DESCRIPTION
Current logic means that services using the new v5.11.0 returns true for `has_tudor_crown?` but not for `can_rebrand?` so is listed with the old style crown.  Adding this version to the list for `can_rebrand` will mean it's displayed with blue crown in the list. 